### PR TITLE
fix: mc-push set +e subshell, mc-edit remove osascript injection

### DIFF
--- a/bin/mc-edit
+++ b/bin/mc-edit
@@ -32,8 +32,7 @@ if [[ -n "$TMUX" ]]; then
   escaped_file=$(printf '%q' "$FILE")
   tmux split-window -h "cd $escaped_path && nvim $escaped_file"
 else
-  # Fallback: open in background terminal
-  osascript -e "tell application \"Terminal\" to do script \"cd '$PROJECT_PATH' && nvim '$FILE'\"" 2>/dev/null || \
+  # Fallback: open directly (avoids shell injection via osascript single-quote interpolation)
   nvim "$FULL_PATH"
 fi
 

--- a/bin/mc-push
+++ b/bin/mc-push
@@ -23,6 +23,7 @@ LOG_FILE="$LOG_DIR/push-$PROJECT.log"
 
 # Push in background, log output, notify on completion
 (
+  set +e  # Prevent errexit from aborting subshell before logging/notifying on push failure
   push_output=$(git push 2>&1)
   push_status=$?
   echo "$push_output" > "$LOG_FILE"


### PR DESCRIPTION
## Remaining CodeRabbit blockers from PR#2

Two fixes that weren't in the 306b261 batch:

### `bin/mc-push` — set +e in background subshell
The subshell inherits `set -e` (errexit) from the parent script. When `git push` fails, `errexit` causes the subshell to abort immediately — before `push_output` is written to `LOG_FILE` and before the `osascript` failure notification runs.

```bash
# Before — push failure aborts subshell, no log, no notification
(
  push_output=$(git push 2>&1)
  push_status=$?
  ...

# After — set +e scoped to subshell only
(
  set +e
  push_output=$(git push 2>&1)
  push_status=$?
  ...
```

### `bin/mc-edit` — remove osascript single-quote injection
The Terminal.app fallback interpolated `$PROJECT_PATH` and `$FILE` inside single quotes in AppleScript. A path like `/Users/o'brien/project` would break the AppleScript string (and could be used for injection). Fallback is now `nvim "$FULL_PATH"` directly.

## Related
- Closes remaining items from CodeRabbit review on redesign PR#2
- Previously fixed: nil guard (model.go:464), empty list guard (model.go:679), UTF-8 truncation, mc-chat set +e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push script's error handling to ensure status notifications display reliably even when operations fail.
  * Streamlined editor launch process for more direct and efficient access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->