### PR TITLE
ci: add build gate to keep production build green (closes #10)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build Gate
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.1.38"
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        run: bun run build


### PR DESCRIPTION
## Summary
- adds GitHub Actions build gate for PRs and main
- runs `bun install --frozen-lockfile` and `bun run build`

## Why
Addresses P0 release blocker #10 by enforcing production build health in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build workflow that runs on pull requests and pushes to main, with a 15-minute timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->